### PR TITLE
Work around 2TB file limit and improve block protocol

### DIFF
--- a/block_proxy/proxy.py
+++ b/block_proxy/proxy.py
@@ -28,10 +28,11 @@
 
 
 import struct
-import socket
+import socket, json, os
 
 SECTOR_SIZE = 512
-
+VERBOSE=0
+VERBOSEERR=1
 
 class BlockProxy:
 
@@ -39,6 +40,7 @@ class BlockProxy:
         self.host = host_port[0]
         self.port = host_port[1]
         self._use_files = False
+        self._use_1tb = False
         if self.host == 'files:':
             self._init_files()
 
@@ -47,14 +49,20 @@ class BlockProxy:
         self._trans_table = {}
         self._use_files = True
         try:
-            f = open(self.port, 'r')
-            entries = [l.strip() for l in f.readlines() if l[0] != '#']
-            f.close()
-            for entry in entries:
-                (path, sub) = entry.split('\t')
-                self._trans_table[path] = sub
-        except:
-            pass
+            with open(self.port, 'r') as f:
+                self._trans_table = json.load(f)
+        except Exception as e:
+            print("Cannot open %s (%s)" %(self.port,str(e)))
+        for k,v in self._trans_table.items():
+            if isinstance(v,list):
+                self._use_1tb = True
+                for i in v[:-1]:
+                    b = os.path.getsize(i)
+                    if not b == 1024*1024*1024*1024:
+                        raise Exception("Expecting parts to be 1TB")
+                b = os.path.getsize(v[-1])
+                if not b <= 1024*1024*1024*1024:
+                    raise Exception("Expecting parts to be <= 1TB")
 
     def read(self, dev_path, offset, count):
         if self._use_files:
@@ -69,64 +77,91 @@ class BlockProxy:
             return self._readv_network(blockv)
 
     def _read_network(self, dev_path, offset, count):
-        request_header = struct.pack('=BQQ', 1, offset, count)
-        request = request_header + dev_path.encode('utf8')
-
+        buf = bytearray(count)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
         try:
             sock.connect((self.host, self.port))
+            request = struct.pack('=BB', ord('r'), 1)
             sock.sendall(request)
-
-            buf = bytearray(count)
-            view = memoryview(buf)
-            while count:
-                nbytes = sock.recv_into(view, count)
-                view = view[nbytes:]
-                count -= nbytes
-
-            # print("[+] BlockProxy: received {} bytes".format(len(buf)))
-            return buf
+            self._read_network_buf(sock, buf, 0, dev_path, offset, count)
         finally:
             sock.close()
+        return buf
+        
+    def _readv_network(self, blockv):
+        
+        count = 0
+        for block in blockv:
+            count += block[2]
+        buf = bytearray(count)
+        VERBOSE
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((self.host, self.port))
+            request = struct.pack('=BB', ord('v'), len(blockv))
+            sock.sendall(request)
+            boff = 0;
+            for block in blockv:
+                self._read_network_buf(sock, buf, boff, block[0], block[1], block[2])
+                boff += block[2]
+        finally:
+            sock.close()
+        return buf
 
+    def _read_network_buf(self, sock, buf, boff, dev_path, offset, count):
+
+        enc_name = dev_path.encode('utf8')
+        request = struct.pack('=QQB', offset, count, len(enc_name)) + enc_name;
+        sock.sendall(request)
+        
+        view = memoryview(buf)
+        while True:
+            answer = bytearray()
+            while len(answer) < 17:
+                answer += sock.recv(1)
+            a, off, l = struct.unpack('=BQQ', answer)
+            if a == ord('n'):
+                if VERBOSE:
+                    print("[>] 'n' received");
+                if (count <= 0):
+                    break;
+                count -= l;
+                while l > 0:
+                    nbytes = sock.recv_into(view[boff+(off-offset):], l)
+                    off += nbytes
+                    l -= nbytes
+            elif a == ord('e'):
+                if VERBOSEERR:
+                    print("[>] 'e' received");
+                break;
+            elif a == ord('l'):
+                if VERBOSE:
+                    print("[>] 'l' received");
+                break;
+            else:
+                print("Unknown code '%d'" %(a))
+                break
+            
+        # print("[+] BlockProxy: received {} bytes".format(len(buf)))
+        
     def _read_files(self, dev_path, offset, count):
-        if dev_path not in self._device_files:
+        idx = offset // (1024*1024*1024*1024)
+        if self._use_1tb:
+            dev_path_r = dev_path + (".%d" %(idx))                    
+            offset = offset % (1024*1024*1024*1024)
+        else:
+            dev_path_r = dev_path
+        if dev_path_r not in self._device_files:
             trans_path = dev_path
             if trans_path in self._trans_table:
                 trans_path = self._trans_table[trans_path]
-            self._device_files[dev_path] = open(trans_path, 'rb')
-        f = self._device_files[dev_path]
+                if self._use_1tb:
+                    trans_path = trans_path[idx]
+            self._device_files[dev_path_r] = open(trans_path, 'rb')
+        f = self._device_files[dev_path_r]
         f.seek(offset)
         data = f.read(count)
         return data
-
-    def _readv_network(self, blockv):
-        request = struct.pack('=BB', 2, len(blockv))
-        count = 0
-        for block in blockv:
-            enc_name = block[0].encode('utf8')
-            subreq = struct.pack('=QQB', block[1], block[2], len(enc_name))
-            request += subreq + enc_name
-            count += block[2]
-
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        try:
-            sock.connect((self.host, self.port))
-            sock.sendall(request)
-
-            buf = bytearray(count)
-            view = memoryview(buf)
-            while count:
-                nbytes = sock.recv_into(view, count)
-                view = view[nbytes:]
-                count -= nbytes
-
-            # print("[+] BlockProxy: received {} bytes".format(len(buf)))
-            return buf
-        finally:
-            sock.close()
 
     def _readv_files(self, blockv):
         data = bytearray()

--- a/block_server/disks_lo.tab
+++ b/block_server/disks_lo.tab
@@ -1,0 +1,4 @@
+# Original path		Translated path
+/dev/loop0 /dev/loop0
+/dev/loop1 /dev/loop1
+/dev/loop2 /dev/loop2

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,29 @@
+all:
+	@echo "make d   : generate raid-z1 testdisks disk[0-2].bin"
+	@echo "make lo  : setup disk[0-2].bin in /dev/loop[0-2]"
+	@echo "make lou : teardown /dev/loop[0-2]"
+	@echo "make runfiles  : run py-zfs-rescue against disk[0-2].bin"
+	@echo "make runserver : run py-zfs-rescue against block server"
+
+d:
+	sudo sh gen_disks.sh
+
+lo: lou
+	if [ ! -f disk0.bin ]; then echo "Run 'make d' to generate disk[0-2]..bin"; exit 1; fi
+	sudo losetup /dev/loop0 disk0.bin
+	sudo losetup /dev/loop1 disk1.bin
+	sudo losetup /dev/loop2 disk2.bin
+
+lou: 
+	-sudo losetup -d /dev/loop0
+	-sudo losetup -d /dev/loop1
+	-sudo losetup -d /dev/loop2
+
+runfiles:
+	bash test_files.sh
+
+runserver:
+	bash test_server.sh
+
+.PHONY: d lo lou files 
+

--- a/test/datatab.txt.templ
+++ b/test/datatab.txt.templ
@@ -1,0 +1,5 @@
+{
+	"/dev/loop0" : [ "--sed--/disk0.bin"],
+	"/dev/loop1" : [ "--sed--/disk1.bin"],
+	"/dev/loop2" : [ "--sed--/disk2.bin"]
+}

--- a/test/gen_disks.sh
+++ b/test/gen_disks.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+dd if=/dev/zero of=disk0.bin bs=1024 count=$((1024*100))
+dd if=/dev/zero of=disk1.bin bs=1024 count=$((1024*100))
+dd if=/dev/zero of=disk2.bin bs=1024 count=$((1024*100))
+
+losetup /dev/loop0 disk0.bin
+losetup /dev/loop1 disk1.bin
+losetup /dev/loop2 disk2.bin
+
+zpool create datapool0 -f -o ashift=12 \
+      -O atime=off -O canmount=off -O compression=lz4 -O normalization=formD \
+      raidz /dev/loop0 /dev/loop1 /dev/loop2
+
+zfs create datapool0/datadir
+
+echo "data0" > /datapool0/datadir/f0.txt
+echo "data1" > /datapool0/datadir/f1.txt
+
+sync
+
+zdb -ddddddd datapool0 > datapool0.txt
+
+zpool export datapool0
+
+losetup -d /dev/loop0
+losetup -d /dev/loop1
+losetup -d /dev/loop2
+
+cat datatab.txt.templ | sed "s@--sed--@$(pwd)@g" > datatab.txt
+
+cat <<EOF > ../block_server/disks_lo.tab
+# Original path		Translated path
+/dev/loop0 /dev/loop0
+/dev/loop1 /dev/loop1
+/dev/loop2 /dev/loop2
+EOF
+
+chmod a+rw \
+      datatab.txt \
+      disk0.bin \
+      disk1.bin \
+      disk2.bin \
+      datapool0.txt \
+      ../block_server/disks_lo.tab

--- a/test/test_files.sh
+++ b/test/test_files.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ ! -f disk0.bin ]; then
+    echo "run 'make d' to generate data[0-2].bin first"
+    exit 1;
+fi
+
+d=$(pwd)
+cd ..;
+python3 zfs_rescue.py --files=${d}/datatab.txt --label=/dev/loop0

--- a/test/test_files.sh
+++ b/test/test_files.sh
@@ -6,4 +6,4 @@ fi
 
 d=$(pwd)
 cd ..;
-python3 zfs_rescue.py --files=${d}/datatab.txt --label=/dev/loop0
+python3 zfs_rescue.py -v --files=${d}/datatab.txt --label=/dev/loop0

--- a/test/test_server.sh
+++ b/test/test_server.sh
@@ -20,6 +20,6 @@ chmod a+rwx /tmp/_server_start.sh
 sudo bash /tmp/_server_start.sh
 
 sleep 1
-python3 ../zfs_rescue.py --label=/dev/loop0
+python3 ../zfs_rescue.py -v --label=/dev/loop0
 
 pkill -9 -f server.py

--- a/test/test_server.sh
+++ b/test/test_server.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+if [ ! -f disk0.bin ]; then
+    echo "run 'make d' to generate data[0-2].bin first"
+    exit 1;
+fi
+
+if ! losetup -l | grep /dev/loop0; then
+    echo "run 'make lo' to setup /dev/loop[0-2]"
+    exit 1;
+fi
+
+d=$(pwd)
+
+cat <<EOF > /tmp/_server_start.sh
+pkill -9 -f server.py
+$(readlink -f ../block_server/server.py) --config=$(readlink -f ${d}/../block_server/disks_lo.tab) &
+echo -n $! > /tmp/_server_pid.txt
+EOF
+chmod a+rwx /tmp/_server_start.sh
+sudo bash /tmp/_server_start.sh
+
+sleep 1
+python3 ../zfs_rescue.py --label=/dev/loop0
+
+pkill -9 -f server.py

--- a/zfs/blocktree.py
+++ b/zfs/blocktree.py
@@ -48,8 +48,8 @@ class BlockTree:
     def _load_from_bptr(self, bptr):
         block_data = None
         for dva in range(3):
-            block_data = self._vdev.read_block(bptr, dva=dva)
-            if block_data:
+            block_data,c = self._vdev.read_block(bptr, dva=dva)
+            if block_data and c:
                 break
         if block_data is None:
             return None
@@ -81,8 +81,8 @@ class BlockTree:
                 b = bpa[i]
                 bpa_data = None
                 for dva in range(3):
-                    bpa_data = self._vdev.read_block(b, dva=dva)
-                    if bpa_data:
+                    bpa_data,c = self._vdev.read_block(b, dva=dva)
+                    if bpa_data and c:
                         break
                 next_bpa = None
                 if bpa_data is not None: 

--- a/zfs/col.py
+++ b/zfs/col.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017 Hristo Iliev <github@hiliev.eu>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class color:
+    PURPLE = '\033[95m'
+    CYAN = '\033[96m'
+    DARKCYAN = '\033[36m'
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+    END = '\033[0m'
+

--- a/zfs/dataset.py
+++ b/zfs/dataset.py
@@ -165,8 +165,8 @@ class Dataset(ObjectSet):
                     print("[-]  Broken block tree")
                     bad_block = True
                 else:
-                    block_data = self._vdev.read_block(bp, dva=0)
-                    if block_data is None:
+                    block_data,c = self._vdev.read_block(bp, dva=0)
+                    if (not c) or block_data is None:
                         print("[-]  Unreadable block")
                         bad_block = True
                 if bad_block:

--- a/zfs/dnode.py
+++ b/zfs/dnode.py
@@ -312,8 +312,8 @@ class DNode:
     def from_bptr(vdev, bptr, dvas=(0, 1)):
         data = None
         for dva in dvas:
-            data = vdev.read_block(bptr, dva=dva)
-            if data:
+            data,c = vdev.read_block(bptr, dva=dva)
+            if data and c:
                 break
         if data is None:
             return None

--- a/zfs/fileobj.py
+++ b/zfs/fileobj.py
@@ -64,8 +64,8 @@ class FileObj:
                     print("[-]  Broken block tree")
                     bad_block = True
                 else:
-                    self._buf = self._vdev.read_block(bptr, dva=0)
-                    if self._buf is None:
+                    self._buf,c = self._vdev.read_block(bptr, dva=0)
+                    if (not c) or self._buf is None:
                         print("[-]  Unreadable block")
                         bad_block = True
             if bad_block:

--- a/zfs/objectset.py
+++ b/zfs/objectset.py
@@ -79,7 +79,7 @@ class ObjectSet:
 
     def _load_os_dnode(self, os_bptr, dva):
         print("[+] Loading object set dnode from", os_bptr)
-        return DNode.from_bptr(self._vdev, os_bptr, dvas=(dva,))
+        return DNode.from_bptr(self._vdev, os_bptr, dvas=(dva,), objset=self)
 
     def __getitem__(self, item):
         return self._get_dnode(item)

--- a/zfs/objectset.py
+++ b/zfs/objectset.py
@@ -96,8 +96,8 @@ class ObjectSet:
             bp = self._blocktree[blockid]
             if bp is not None:
                 for dva in range(3):
-                    block_data = self._vdev.read_block(bp, dva=dva)
-                    if block_data:
+                    block_data,c = self._vdev.read_block(bp, dva=dva)
+                    if block_data and c:
                         break
             self._block_cache[blockid] = block_data
         if block_data is None:

--- a/zfs/zap.py
+++ b/zfs/zap.py
@@ -223,6 +223,8 @@ class FatZap:
         return self._entries.get(item)
 
 def _choose_zap_factory(data, dbsize):
+    if (len(data) <8):
+        return MicroZap() # return empty microzap
     (block_type,) = struct.unpack("=Q", data[:8])
     if block_type == ZBT_MICRO:
         zap = MicroZap()
@@ -237,14 +239,14 @@ def _choose_zap_factory(data, dbsize):
 def _blockptrar_zap_factory(vdev, bpa, dbsize, nblocks):
     data = bytearray()
     for i in range(nblocks):
-        d = vdev.read_block(bpa[i])
-        if not (d is None):
+        d,c = vdev.read_block(bpa[i])
+        if c and not (d is None):
             data += d
     return _choose_zap_factory(data, dbsize)
 
 def _indirect_zap_factory(vdev, bptr, dbsize, nblocks):
-    data = vdev.read_block(bptr)
-    if data is None:
+    data,c = vdev.read_block(bptr)
+    if (not c) or data is None:
         return None
     # Data contains first indirection block
     bpa = BlockPtrArray(data)

--- a/zfs_rescue.py
+++ b/zfs_rescue.py
@@ -35,6 +35,8 @@ from zfs.zap import zap_factory
 from zfs.dataset import Dataset
 from zfs.objectset import ObjectSet
 from zfs.zio import RaidzDevice             # or MirrorDevice
+from zfs.blocktree import BlockTree
+
 import argparse
 
 from os import path
@@ -46,6 +48,9 @@ parser.add_argument('--files', '-f', dest='files', type=str, default=None,
 parser.add_argument('--label', '-l', dest='label', type=str, default='/dev/dsk/c3t0d0s7',
                     help='Device where to read the initial label from')
 args = parser.parse_args()
+
+if args.verbose > 0:
+    BlockTree.VERBOSE_TRAVERSE = 1
 
 BLK_PROXY_ADDR = ("localhost", 24892)       # network block server
 if not args.files is None:

--- a/zfs_rescue.py
+++ b/zfs_rescue.py
@@ -35,13 +35,23 @@ from zfs.zap import zap_factory
 from zfs.dataset import Dataset
 from zfs.objectset import ObjectSet
 from zfs.zio import RaidzDevice             # or MirrorDevice
+import argparse
 
 from os import path
 
-BLK_PROXY_ADDR = ("localhost", 24892)       # network block server
-# BLK_PROXY_ADDR = ("files:", "disks.tab")  # local device nodes
+parser = argparse.ArgumentParser(description='zfs_rescue')
+parser.add_argument('--verbose', '-v', dest='verbose', action='count', default=0)
+parser.add_argument('--files', '-f', dest='files', type=str, default=None,
+                    help='Read blocks from files, specify disks.tab location')
+parser.add_argument('--label', '-l', dest='label', type=str, default='/dev/dsk/c3t0d0s7',
+                    help='Device where to read the initial label from')
+args = parser.parse_args()
 
-BLK_INITIAL_DISK = "/dev/dsk/c3t0d0s7"      # device to read the label from
+BLK_PROXY_ADDR = ("localhost", 24892)       # network block server
+if not args.files is None:
+    BLK_PROXY_ADDR = ("files:", args.files)  # local device nodes
+BLK_INITIAL_DISK = args.label      # device to read the label from
+
 TXG = -1                                    # select specific transaction or -1 for the active one
 
 TEMP_DIR = "/tmp"


### PR DESCRIPTION
- Generate testdisks via losetup
- When using local disk images BLK_PROXY_ADDR = ("files:","datatab.txt")
  use json structure inside datatab.txt.
- To enable disk images bigger than 2TB split up a disk into 1 TB
  chunks. The disk is specified as an array of chunks.
- Improve the server protocol:
  Send data in chunks of 256kB. Send with packet prefixes and handle error:
  'n' : next datachunk < 256kB
  'e' : error occured
  'l' : last chunk transmitted
- supply a testcase for file/server based run of py-zfs-rescue:
  test/test_files.sh
  test/test_server.sh

examples:

8< -------------- datatab.txt -----------------
{
	"/dev/disk/by-id/ata-WDC_WD30EZRX-00D8PB0_WD-WMC4N1642572-part1" : [ "/mnt/parts-disk-id0-err-ata-WDC_WD30EZRX-00D8PB0_WD-WMC4N1642572-part1.0", "/mnt/parts-disk-id0-err-ata-WDC_WD30EZRX-00D8PB0_WD-WMC4N1642572-part1.1", "/mnt/parts-disk-id0-err-ata-WDC_WD30EZRX-00D8PB0_WD-WMC4N1642572-part1.2"],
	"/dev/disk/by-id/ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N1KPRKPX-part1" : [ "/mnt/parts-disk-id1-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N1KPRKPX-part1.0", "/mnt/parts-disk-id1-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N1KPRKPX-part1.1", "/mnt/parts-disk-id1-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N1KPRKPX-part1.2"],
	"/dev/disk/by-id/ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N7ZXC1E0-part1" : [ "/mnt/parts-disk-id2-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N7ZXC1E0-part1.0", "/mnt/parts-disk-id2-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N7ZXC1E0-part1.1", "/mnt/parts-disk-id2-ata-WDC_WD30EFRX-68EUZN0_WD-WCC4N7ZXC1E0-part1.2"]
}
8< --------------------------------------------

8< -------------- datatab.txt -----------------
{
	"/dev/loop0" : [ "/home/test/disk0.bin"],
	"/dev/loop1" : [ "/home/test/disk1.bin"],
	"/dev/loop2" : [ "/home/test/disk2.bin"]
}
8< --------------------------------------------